### PR TITLE
Support 24 hour format on week view

### DIFF
--- a/lib/calendar/google_calendar.rb
+++ b/lib/calendar/google_calendar.rb
@@ -1,7 +1,7 @@
 module Plugins
   class GoogleCalendar < Base
     def locals
-      { events:, event_layout:, include_description:, first_day:, scroll_time:, today_in_tz: }
+      { events:, event_layout:, include_description:, first_day:, scroll_time:, hour_12_format:, today_in_tz: }
     end
 
     class << self
@@ -119,12 +119,12 @@ module Plugins
 
     def time_zone = user.tz || 'America/New_York'
 
+    def hour_12_format
+      settings['time_format'] == 'am/pm'
+    end
+
     def time_format
-      if settings['time_format'] == 'am/pm'
-        "%I:%M %p"
-      else
-        "%R"
-      end
+      hour_12_format ? "%I:%M %p" : "%R"
     end
 
     def event_should_be_ignored?(event, calendar_email)

--- a/lib/calendar/ics_calendar.rb
+++ b/lib/calendar/ics_calendar.rb
@@ -4,7 +4,7 @@ module Plugins
     include Ics::Calendar
 
     def locals
-      { events:, event_layout:, include_description:, first_day:, scroll_time:, today_in_tz: }
+      { events:, event_layout:, include_description:, first_day:, scroll_time:, hour_12_format:, today_in_tz: }
     end
   end
 end
@@ -175,12 +175,12 @@ module Ics
 
     def time_zone = user.tz || 'America/New_York'
 
+    def hour_12_format
+      settings['time_format'] == 'am/pm'
+    end
+
     def time_format
-      if settings['time_format'] == 'am/pm'
-        "%I:%M %p"
-      else
-        "%R"
-      end
+      hour_12_format ? "%I:%M %p" : "%R"
     end
 
     def event_should_be_ignored?(event)

--- a/lib/calendar/views/_full_week.html.erb
+++ b/lib/calendar/views/_full_week.html.erb
@@ -43,6 +43,12 @@
       initialView: 'timeGridFourDay', // 'dayGridWeek' shows a week but does not show events as blocks with diff heights per time length
       scrollTime: '<%= scroll_time %>', // without this, view begins at 12am (creating white space)
       slotMinTime: '<%= scroll_time %>', // required in-addition to scrollTime, otherwise calendar lib will ignore scrollTime if events would be hidden
+      slotLabelFormat: {
+        hour: 'numeric',
+        minute: '2-digit',
+        omitZeroMinute: <%= hour_12_format %>,
+        hour12: <%= hour_12_format %>
+      },
       views: {
         timeGridFourDay: {
           type: 'timeGrid',


### PR DESCRIPTION
This is untested as I don't have the full TRMNL stack, but I created a HTML file with these settings in and it looks like the times are rendered correctly for both 12 hours and 24 hours.  See below:

![image](https://github.com/user-attachments/assets/e064f7b5-2dd7-42f8-a341-730758d9edc6)
![image](https://github.com/user-attachments/assets/5e0d18a8-59d2-4217-865c-ac84cfbf6b54)
