### PR TITLE
Match date/time cutoff and add include_past_events in ICS to match the GCal plugin

### DIFF
--- a/lib/calendar/ics_calendar.rb
+++ b/lib/calendar/ics_calendar.rb
@@ -184,7 +184,7 @@ module Ics
     end
 
     def event_should_be_ignored?(event)
-      includes_ignored_phrases?(event) || ignore_based_on_status?(event)
+      includes_ignored_phrases?(event) || ignore_based_on_status?(event) || ignore_based_on_time?(event)
     end
 
     def ignore_based_on_status?(event)
@@ -193,6 +193,10 @@ module Ics
       # include non-confirmed events if user prefers to see them (received requests for both options)
       # if this branch is reached, event.status == [nil, 'rejected'] etc
       settings['event_status_filter'] == 'confirmed_only'
+    end
+
+    def ignore_based_on_time?(event)
+      event.dtend.in_time_zone(time_zone) < cutoff_time
     end
 
     def includes_ignored_phrases?(event)
@@ -256,6 +260,10 @@ module Ics
       return settings['scroll_time'] if settings['scroll_time'].present?
 
       events.values.flatten.reject { |e| e[:all_day] }.map { |e| e[:start_full].to_time.strftime("%H:00:00") }.min || '08:00:00'
+    end
+
+    def cutoff_time
+      settings['include_past_events'] == 'yes' ? now_in_tz.beginning_of_day : now_in_tz
     end
   end
 end

--- a/lib/calendar/ics_calendar.rb
+++ b/lib/calendar/ics_calendar.rb
@@ -123,7 +123,7 @@ module Ics
         evt.dtstart = recurrence.start_time.in_time_zone(time_zone)
         evt.dtend = recurrence.end_time.in_time_zone(time_zone)
 
-        evt
+        evt if evt.dtstart >= cutoff_time
       end
     end
 

--- a/lib/calendar/ics_calendar.rb
+++ b/lib/calendar/ics_calendar.rb
@@ -19,7 +19,7 @@ module Ics
     def prepare_events
       all_events = []
       calendars.each do |cal|
-        calendar_events = cal.events.sort_by(&:dtstart).select { |m| m.dtstart >= DateTime.now - 1.days }
+        calendar_events = cal.events.sort_by(&:dtstart).select { |m| m.dtstart >= now_in_tz.beginning_of_day }
         calendar_events.each do |event|
           next unless event
 

--- a/lib/calendar/ics_calendar.rb
+++ b/lib/calendar/ics_calendar.rb
@@ -19,7 +19,7 @@ module Ics
     def prepare_events
       all_events = []
       calendars.each do |cal|
-        calendar_events = cal.events.sort_by(&:dtstart).select { |m| m.dtstart >= now_in_tz.beginning_of_day }
+        calendar_events = cal.events.sort_by(&:dtstart).select { |m| m.dtstart.in_time_zone(time_zone) >= cutoff_time }
         calendar_events.each do |event|
           next unless event
 


### PR DESCRIPTION
Noticed the Fastmail (aka bare ICS) behavior was a bit off and not matching what GCal did, namely:

1. Recurring events from the prior day would always show, e.g., today is the 22nd at 9pm, but events from the 21 at 11:30am were showing. This seems to be because the filtering for events was -1 day instead of start of the day when getting `calendar_events`
2. Filter on `occurences` expansion, which should also filter if prior to `cutoff_time` (may be redundant?)
3. Added a config matching `include_past_events` which I assume will take work in another repo that isn't public for the main web interface.

Not sure how to test these portions yet, but I think these were pretty simple changes mostly matching the other plugin. Looking forward to more developing on this platform! For now left this in a draft to get early feedback, and maybe a way that these can be tested (may try to make a harness if there is no way).