### PR TITLE
Rebuild calendars

### DIFF
--- a/lib/calendar/google_calendar.rb
+++ b/lib/calendar/google_calendar.rb
@@ -137,7 +137,7 @@ module Plugins
 
     def time_format
       if settings['time_format'] == 'am/pm'
-        "%I:%M %p"
+        "%-I:%M %p"
       else
         "%R"
       end

--- a/lib/calendar/ics_calendar.rb
+++ b/lib/calendar/ics_calendar.rb
@@ -19,17 +19,9 @@ module Ics
     def prepare_events
       all_events = []
       calendars.each do |cal|
-        calendar_events = cal.events.sort_by(&:dtstart).select do |event|
-          if event.dtstart.instance_of?(Icalendar::Values::Date)
-            event.dtstart >= now_in_tz.to_date && event.dtstart <= time_max.to_date
-          else
-            event.dtstart >= now_in_tz && event.dtstart <= time_max
-          end
-        end
-        calendar_events.each do |event|
+        cal.events.each do |event|
           next unless event
 
-          # process recently created recurring events
           if event.rrule.present?
             occurences(event).each { |recurring_event| all_events << prepare_event(recurring_event) }
           else
@@ -38,12 +30,11 @@ module Ics
           end
         end
       end
-
-      cached_recurring_events.each do |event|
-        occurences(event).each { |recurring_event| all_events << prepare_event(recurring_event) }
-      end
-
-      all_events.compact.sort_by { |e| e[:date_time] }.group_by { |e| e[:day] }
+      all_events
+        .compact
+        .select { it[:date_time] >= now_in_tz && it[:date_time] <= time_max }
+        .sort_by { |e| e[:date_time] }
+        .group_by { |e| e[:day] }
     rescue Plugins::Helpers::Errors::InvalidURL
       handle_erroring_state("ics_url is invalid")
       {}
@@ -55,65 +46,23 @@ module Ics
       {}
     end
 
-    def sync_recurring_events
-      recurring_events = []
-      calendars.each do |cal|
-        calendar_events = cal.events.sort_by(&:dtstart).select { |m| m.dtstart >= DateTime.now - 5.years }
-        calendar_events.each do |event|
-          next unless event && event.rrule.present?
-
-          recurring_events << {
-            summary: event.summary,
-            description: event.description,
-            status: event.status,
-            dtstart: event.dtstart,
-            dtend: event.dtend,
-            rrule: event.rrule.map(&:value_ical) # => ["FREQ=WEEKLY;UNTIL=20250617T120000Z;INTERVAL=1;BYDAY=TU;WKST=SU"]
-          }
-        end
-      end
-
-      plugin_settings.persistence_data['recurring_events'] = recurring_events
-      plugin_settings.save
-    end
-
-    def cached_recurring_events
-      r_events = plugin_settings.persistence_data['recurring_events'] || []
-
-      r_events.map do |re|
-        ie = Icalendar::Event.new
-
-        ie.summary = re['summary']
-        ie.description = re['description']
-        ie.status = re['status']
-        ie.dtstart = re['dtstart']&.to_datetime
-        ie.dtend = re['dtend']&.to_datetime
-
-        re['rrule'].each do |rule|
-          ie.append_rrule Icalendar::Values::Recur.new(rule)
-        end
-
-        ie
-      end
-    end
-
     def prepare_event(event)
       return if event_should_be_ignored?(event)
 
       # some params below are only needed for 1 or more event_layout options but not all
       # however all must be included as user may set event_layout==week, then create a mashup with event_layout==default
       layout_params = {
-        start_full: event.dtstart,
-        end_full: event.dtend,
+        start_full: event.dtstart&.in_time_zone(time_zone),
+        end_full: event.dtend&.in_time_zone(time_zone),
         start: event.dtstart&.strftime(time_format),
         end: event.dtend&.strftime(time_format)
       }
 
       {
-        summary: event.summary || 'Busy', # likely a private event that doesn't share full details with connected calendar
+        summary: event.summary.to_s || 'Busy', # likely a private event that doesn't share full details with connected calendar
         description: sanitize_description(event.description),
-        status: event.status,
-        date_time: event.dtstart,
+        status: event.status.to_s,
+        date_time: event.dtstart.in_time_zone(time_zone),
         day: event.dtstart.in_time_zone(time_zone).strftime('%B %d'),
         all_day: all_day_event?(event)
       }.merge(layout_params)
@@ -121,17 +70,29 @@ module Ics
 
     def sanitize_description(description)
       description = description.join(', ') if description.is_a?(Icalendar::Values::Helpers::Array)
-      Rails::Html::FullSanitizer.new.sanitize(description) || 'No description'
+      return 'No description' if description.nil?
+
+      Rails::Html::FullSanitizer.new.sanitize(description.strip.split("\n").first&.strip || 'No description')
     end
 
     def occurences(event)
+      if event.dtstart.is_a?(Icalendar::Values::Date)
+        event.dtstart = event.dtstart.in_time_zone(time_zone)
+        event.dtend = event.dtend.in_time_zone(time_zone)
+      end
+
       recurrences = event.occurrences_between(recurring_event_start_date, recurring_event_end_date)
 
       recurrences.map do |recurrence|
         evt = event.dup
-        evt.dtstart = recurrence.start_time.in_time_zone(time_zone)
-        evt.dtend = recurrence.end_time.in_time_zone(time_zone)
-
+        evt.dtstart = recurrence.start_time.in_time_zone(time_zone).change(
+          hour: event.dtstart.hour,
+          min: event.dtstart.min
+        )
+        evt.dtend = recurrence.end_time.in_time_zone(time_zone).change(
+          hour: event.dtend.hour,
+          min: event.dtend.min
+        )
         evt
       end
     end
@@ -159,13 +120,15 @@ module Ics
     end
 
     def all_day_event?(event)
-      if event.rrule.present?
-        (event.dtend.to_date - event.dtstart.to_date).to_i >= 1 # 24+ hours long, ex: 00:00 - 00:00 (next day)
-      else
-        # this check only works for regular events
-        # cached_recurring_events lose data type artifacts
-        event.dtstart.instance_of?(Icalendar::Values::Date)
+      return true if event.dtstart.to_datetime.hour.zero? && event.dtstart.to_datetime.min.zero?
+      return true if event.dtstart.instance_of?(Icalendar::Values::Date)
+
+      if event.rrule.present? && event.dtend
+        # 24+ hours long, ex: 00:00 - 00:00 (next day)
+        return (event.dtend.to_date - event.dtstart.to_date).to_i >= 1
       end
+
+      false
     end
 
     def calendars
@@ -173,9 +136,9 @@ module Ics
 
       cals = []
       cal_urls.each do |url|
-        response = fetch(url)
-        raise Plugins::Helpers::Errors::InvalidURL if response.code == 404
+        response = HTTParty.get(url, headers:, verify: false) ## Not using fetch, as fetch has a timeout of 10s with 3 retries so 30s in total
         raise Plugins::Helpers::Errors::DataFetchError if response.nil?
+        raise Plugins::Helpers::Errors::InvalidURL if response.code == 404
 
         cals << Icalendar::Calendar.parse(response&.body).first # is array but should just have 1
       end
@@ -187,13 +150,15 @@ module Ics
 
     def time_format
       if settings['time_format'] == 'am/pm'
-        "%I:%M %p"
+        "%-I:%M %p"
       else
         "%R"
       end
     end
 
     def event_should_be_ignored?(event)
+      return false if event.instance_of?(Icalendar::Recurrence::Occurrence)
+
       includes_ignored_phrases?(event) || ignore_based_on_status?(event)
     end
 
@@ -230,7 +195,7 @@ module Ics
                      7
                    end
 
-      (now_in_tz + days_ahead.days)
+      (now_in_tz.end_of_day + days_ahead.days)
     end
 
     def now_in_tz
@@ -240,10 +205,6 @@ module Ics
     # required to ensure locals data has a 'diff' at least 1x per day
     # given week/month view 'highlight' current day
     # without this local, previous day will be highlighted if events dont change
-
-    def today
-      Date.today
-    end
 
     def today_in_tz
       now_in_tz.to_date.to_s
@@ -257,6 +218,12 @@ module Ics
 
     def first_day
       Date.strptime(settings['first_day'], '%a').wday
+    end
+
+    def headers
+      return {} unless settings['headers']
+
+      string_to_hash(settings['headers'])
     end
 
     # ability to hard-code each day's first time slot in event_layout=week mode

--- a/lib/calendar/views/_all_day_event.html.erb
+++ b/lib/calendar/views/_all_day_event.html.erb
@@ -1,0 +1,11 @@
+<div class="item">
+  <div class="meta">
+    <span class="index">#</span>
+  </div>
+  <div class="content">
+    <span class="title title--small"><%= event[:summary] %></span>
+    <% if include_description %>
+      <span class="description"><%= event[:description] %></span>
+    <% end %>
+  </div>
+</div>

--- a/lib/calendar/views/_common.html.erb
+++ b/lib/calendar/views/_common.html.erb
@@ -17,6 +17,10 @@
     overflow: visible;
   }
 
+  .fc-daygrid-dot-event .fc-event-title {
+    font-weight: 400;
+  }
+
   .fc-col-header-cell {
     font-family: 'NicoClean';
     font-size: 16px;
@@ -32,6 +36,10 @@
 
   table.fc-col-header {
     width: 800px !important;
+  }
+
+  table.fc-col-header col {
+    width: 52px !important; /* defaults 41px, mis-aligns date headings */
   }
 
   .fc-timegrid-divider {
@@ -90,7 +98,7 @@
   }
 
   .fc-day {
-    width: 108px;
+    width: 104px;
   }
 
   /* in month view, next month's dates default 0.3 opacity which renders them invisible */

--- a/lib/calendar/views/_full.html.erb
+++ b/lib/calendar/views/_full.html.erb
@@ -3,5 +3,5 @@
 <% elsif event_layout == 'month' %>
   <%= render partial: 'plugins/calendars/full_month', locals: local_assigns %>
 <% else %>
-  <%= render partial: 'plugins/calendars/full_default', locals: local_assigns %>
+  <%= render partial: 'plugins/calendars/full_auto', locals: local_assigns %>
 <% end %>

--- a/lib/calendar/views/_full_auto.html.erb
+++ b/lib/calendar/views/_full_auto.html.erb
@@ -1,7 +1,7 @@
 <div class="view view--full">
   <div class="layout">
     <div class="columns">
-      <% events.first(3).to_h.each do |day_of_events| %>
+      <% events.sort_by { |k,_v| Date.parse(k.to_s) }.first(3).to_h.each do |day_of_events| %>
         <div class="column">
           <div class="list">
             <span class="label"><%= day_of_events[0] %></span>
@@ -11,21 +11,13 @@
             <% hidden_events_count = day_of_events[1].size - all_day_events.size - visible_events.size %>
 
             <% all_day_events.each do |event| %>
-              <div class="item">
-                <div class="meta">
-                  <span class="index">#</span>
-                </div>
-                <div class="content">
-                  <span class="title title--small"><%= event[:summary] %></span>
-                  <% if include_description %><span class="description"><%= event[:description] %></span><% end %>
-                </div>
-              </div>
+              <%= render partial: 'plugins/calendars/all_day_event', locals: { event: event, include_description: } %>
             <% end %>
 
-            <% visible_events.each_with_index do |event, idx| %>
+            <% visible_events.each do |event| %>
               <div class="item">
                 <div class="meta">
-                  <span class="index"><%= idx + 1 %></span>
+                  <span class="index"></span>
                 </div>
                 <div class="content">
                   <span class="title title--small"><%= event[:summary] %></span>
@@ -52,5 +44,5 @@
     </div>
   </div>
 
-  <%= render partial: "lib/calendar/views/title_bar", locals: local_assigns %>
+  <%= render partial: "plugins/calendars/title_bar", locals: local_assigns %>
 </div>

--- a/lib/calendar/views/_full_month.html.erb
+++ b/lib/calendar/views/_full_month.html.erb
@@ -23,6 +23,7 @@
   document.addEventListener('DOMContentLoaded', function() {
     var calendarEl = document.getElementById('calendar');
     var calendar = new FullCalendar.Calendar(calendarEl, {
+      now: '<%= today_in_tz %>',
       timeZone: new Date('<%= events.values.flatten.reject { |e| e[:all_day] }.first&.dig(:start_full) %>').getTimezoneOffset(),
       headerToolbar: false,
       initialView: 'dayGridMonth',

--- a/lib/calendar/views/_full_week.html.erb
+++ b/lib/calendar/views/_full_week.html.erb
@@ -38,6 +38,7 @@
   document.addEventListener('DOMContentLoaded', function() {
     var calendarEl = document.getElementById('calendar');
     var calendar = new FullCalendar.Calendar(calendarEl, {
+      now: '<%= today_in_tz %>',
       timeZone: new Date('<%= events.values.flatten.reject { |e| e[:all_day] }.first&.dig(:start_full) %>').getTimezoneOffset(),
       headerToolbar: false,
       initialView: 'timeGridFourDay', // 'dayGridWeek' shows a week but does not show events as blocks with diff heights per time length

--- a/lib/calendar/views/_half_horizontal.html.erb
+++ b/lib/calendar/views/_half_horizontal.html.erb
@@ -1,35 +1,38 @@
 <div class="view view--half_horizontal">
-  <div class="layout">
-    <div class="columns">
+  <div class="layout" style="justify-content: flex-start; padding-bottom: 0px">
+    <div style="display: flex; height: 100%; width: 52%; flex-direction: column; flex-wrap: wrap; gap: var(--list-gap-small)">
+      <% events.sort_by { |k,_v| Date.parse(k.to_s) }.first(3).to_h.each do |day_of_events| %>
+        <% all_day_events = day_of_events[1].select { |e| e[:all_day] } %>
+        <% visible_events = (day_of_events[1] - all_day_events) %>
 
-      <% events_sorted = events.values.flatten.sort_by { |e| e[:date_time] }.group_by { |e| e[:day] } %>
-      <% events_sorted.first(2).to_h.each do |day_of_events| %>
+        <span class="label"><%= day_of_events[0] %></span>
 
-        <div class="column">
-          <% max_event_count = include_description ? 2 : 3 %>
-          <div class="list">
-            <% day_of_events[1][0..max_event_count].each_with_index do |event, idx| %>
-              <div class="item">
-                <div class="meta">
-                  <span class="index"><%= idx + 1 %></span>
-                </div>
-                <div class="content">
-                  <span class="title title--small"><%= event[:summary] %></span>
-                  <% if include_description %><span class="description"><%= event[:description] %></span><% end %>
-                  <div class="flex gap--xsmall">
-                    <span class="label label--small label--underline"><%= day_of_events[0] %></span>
-                    <span class="label label--small label--underline"><%= "#{event[:start]}" %> - <%= event[:end] %></span>
-                    <!-- <span class="label label--small label--underline"><%= event[:status] %></span> -->
-                  </div>
-                </div>
+        <% all_day_events.each do |event| %>
+            <%= render partial: 'plugins/calendars/all_day_event', locals: { event: event, include_description: } %>
+          <% end %>
+
+        <% visible_events.each_with_index do |event, idx| %>
+          <div class="item">
+            <div class="meta">
+              <span class="index"><%= idx + 1 %></span>
+            </div>
+            <div class="content">
+              <span class="title title--small"><%= event[:summary] %></span>
+              <% if include_description %>
+                <span class="description"><%= event[:description] %></span>
+              <% end %>
+              <div class="flex gap--xsmall">
+                <span class="label label--small label--underline"><%= day_of_events[0] %></span>
+                <span class="label label--small label--underline"><%= "#{event[:start]}" %> - <%= event[:end] %></span>
+                <!-- <span class="label label--small label--underline"><%= event[:status] %></span> -->
               </div>
-            <% end %>
+            </div>
           </div>
-        </div>
+        <% end %>
       <% end %>
 
     </div>
   </div>
 
-  <%= render partial: "lib/calendar/views/title_bar", locals: local_assigns %>
+  <%= render partial: "plugins/calendars/title_bar", locals: local_assigns %>
 </div>

--- a/lib/calendar/views/_half_vertical.html.erb
+++ b/lib/calendar/views/_half_vertical.html.erb
@@ -1,12 +1,17 @@
 <div class="view view--half_vertical">
-  <div class="layout">
-    <div class="column" data-list-limit="true" data-list-max-height="340">
-      <% events_sorted = events.values.flatten.sort_by { |e| e[:date_time] }.group_by { |e| e[:day] } %>
-      <% events_sorted.first(2).to_h.each do |day_of_events| %>
+  <div class="layout" style="flex-flow: wrap;">
+    <div class="column">
+      <% events.sort_by { |k,_v| Date.parse(k.to_s) }.first(4).to_h.each do |day_of_events| %>
+        <% all_day_events = day_of_events[1].select { |e| e[:all_day] } %>
+        <% visible_events = (day_of_events[1] - all_day_events) %>
         <div class="list">
           <span class="label"><%= day_of_events[0] %></span>
 
-          <% day_of_events[1].each_with_index do |event, idx| %>
+          <% all_day_events.each do |event| %>
+            <%= render partial: 'plugins/calendars/all_day_event', locals: { event: event, include_description: } %>
+          <% end %>
+
+          <% visible_events.each_with_index do |event, idx| %>
             <div class="item">
               <div class="meta">
                 <span class="index"><%= idx + 1 %></span>
@@ -25,5 +30,5 @@
     </div>
   </div>
 
-  <%= render partial: "lib/calendar/views/title_bar", locals: local_assigns %>
+  <%= render partial: "plugins/calendars/title_bar", locals: local_assigns %>
 </div>

--- a/lib/calendar/views/_quadrant.html.erb
+++ b/lib/calendar/views/_quadrant.html.erb
@@ -1,12 +1,16 @@
 <div class="view view--quadrant">
   <div class="layout layout--col" style="justify-content: <%= events.count > 1 ? 'flex-start' : 'center' %>">
-    <% events_sorted = events.values.flatten.sort_by { |e| e[:date_time] }.group_by { |e| e[:day] } %>
-    <% events_sorted.first(1).to_h.each do |day_of_events| %>
+    <% events.sort_by { |k,_v| Date.parse(k.to_s) }.first(2).to_h.each do |day_of_events| %>
+      <% all_day_events = day_of_events[1].select { |e| e[:all_day] } %>
+      <% visible_events = (day_of_events[1] - all_day_events) %>
 
       <div class="list">
         <span class="label"><%= day_of_events[0] %></span>
-        <% visible_events = day_of_events[1][0..2] %>
-        <% hidden_events_count = day_of_events[1].size - visible_events.size %>
+
+        <% all_day_events.each do |event| %>
+          <%= render partial: 'plugins/calendars/all_day_event', locals: { event: event, include_description: } %>
+        <% end %>
+
         <% visible_events.each_with_index do |event, idx| %>
           <div class="item">
             <div class="meta">
@@ -20,17 +24,9 @@
             </div>
           </div>
         <% end %>
-        <% if hidden_events_count > 0 %>
-          <div class="item">
-            <div class="meta"></div>
-            <div class="content">
-              <span class="title title--small">And <%= hidden_events_count %> more</span>
-            </div>
-          </div>
-        <% end %>
       </div>
     <% end %>
   </div>
 
-  <%= render partial: "lib/calendar/views/title_bar", locals: local_assigns %>
+  <%= render partial: "plugins/calendars/title_bar", locals: local_assigns %>
 </div>


### PR DESCRIPTION
fixes several issues including:

- parsed timezone is incorrect if the event owner is in a different time zone than calendar owner / recipient
- recurring events older than 5 years do not appear, and changes to recurring events are not synced
- all day events do not appear in mashup layouts