### PR TITLE
Added BVG (Berlin) Transport plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,6 @@ native plugin structure:
 - [Year In Progress](https://github.com/monsieurm/trmnl-yearinprogress) by [@monsieurm](https://github.com/monsieurm)
 - [Who's That Pokémon?](https://github.com/sriniketh/trmnl-plugin-whos-that-pokemon) by [@sriniketh](https://github.com/sriniketh)
 - [Canvas](https://github.com/JoshuaBrest/canvas-trmnl) by [@JoshuaBrest](https://github.com/JoshuaBrest)
+- [BVG (Berlin) Public Transport](https://github.com/danmunoz/trmnl-bvg-transit) by [@Danmunoz](https://github.com/danmunoz)
 
 to be featured here, add `trmnl` topic to your repo, then open a PR or join the developer-only Discord server (link inside TRMNL UI).


### PR DESCRIPTION
Berlin's BVG public transportation plugin.

<img width="823" alt="BVG-TRMNL" src="https://github.com/user-attachments/assets/0a911532-bb49-4b01-8341-ba34701e51e8" />
