### PR TITLE
Update github current streak logic to not break streak based on current day

### DIFF
--- a/lib/github_commit_graph/github_commit_graph.rb
+++ b/lib/github_commit_graph/github_commit_graph.rb
@@ -79,9 +79,7 @@ module Plugins
       streak = 0
       
       # The current day can count towards the streak but it shouldn't break the streak
-      if (days.last()['contributionCount']).positive?
-        streak += 1
-      end
+      streak += 1 if days.last['contributionCount'].positive?
       
       days[0..-2].reverse_each do |day|
         break if (day['contributionCount']).zero?

--- a/lib/github_commit_graph/github_commit_graph.rb
+++ b/lib/github_commit_graph/github_commit_graph.rb
@@ -77,7 +77,13 @@ module Plugins
 
     def current_streak(days)
       streak = 0
-      days.reverse_each do |day|
+      
+      # The current day can count towards the streak but it shouldn't break the streak
+      if (days.last()['contributionCount']).positive?
+        streak += 1
+      end
+      
+      days[0..-2].reverse_each do |day|
         break if (day['contributionCount']).zero?
 
         streak += 1

--- a/lib/github_commit_graph/github_commit_graph.rb
+++ b/lib/github_commit_graph/github_commit_graph.rb
@@ -79,7 +79,7 @@ module Plugins
       streak = 0
       
       # The current day can count towards the streak but it shouldn't break the streak
-      streak += 1 if days.last['contributionCount'].positive?
+      streak += 1 if days.last[:contributionCount].positive?
       
       days[0..-2].reverse_each do |day|
         break if (day['contributionCount']).zero?


### PR DESCRIPTION
The current day's contributions should count _towards_ the current streak, but a lack of contributions today _shouldn't break_ the streak. This is because a streak doesn't end until there's a full day without contributions, and the current day isn't a full day.

I tested the stats fetching logic by itself and verified that it's now correctly calculating the current streak but I don't know how to test these plugins within the context of an actual trmnl device.

![Screenshot 2025-04-24 at 9 18 04 AM](https://github.com/user-attachments/assets/0d9ab69d-d5a7-4772-aedb-62ca811848f8)
![Screenshot 2025-04-24 at 9 17 01 AM](https://github.com/user-attachments/assets/653b0647-0a5e-43af-9049-a8057cd89ffd)
