### PR TITLE
misc Calendar improvements

### DIFF
--- a/lib/calendar/views/_full_auto.html.erb
+++ b/lib/calendar/views/_full_auto.html.erb
@@ -7,14 +7,14 @@
             <span class="label"><%= day_of_events[0] %></span>
             <% max_event_count = include_description ? 4 : 7 %>
             <% all_day_events = day_of_events[1].select { |e| e[:all_day] }[0..max_event_count] %>
-            <% visible_events = (day_of_events[1] - all_day_events)[0..(max_event_count-all_day_events.count)] %>
-            <% hidden_events_count = day_of_events[1].size - all_day_events.size - visible_events.size %>
+            <% regular_events = (day_of_events[1] - all_day_events)[0..(max_event_count-all_day_events.count)] %>
+            <% hidden_events_count = day_of_events[1].size - all_day_events.size - regular_events.size %>
 
             <% all_day_events.each do |event| %>
               <%= render partial: 'plugins/calendars/all_day_event', locals: { event: event, include_description: } %>
             <% end %>
 
-            <% visible_events.each do |event| %>
+            <% regular_events.each do |event| %>
               <div class="item">
                 <div class="meta">
                   <span class="index"></span>

--- a/lib/calendar/views/_full_month.html.erb
+++ b/lib/calendar/views/_full_month.html.erb
@@ -14,10 +14,7 @@
 
 <div id="calendar" style="height: 480px; width: 800px"></div>
 
-<script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.js'></script>
-
-<!-- TODO: a newer version is available, but some el classes have changed so our style overrides are not applied -->
-<!-- <script src='https://cdn.jsdelivr.net/npm/fullcalendar@7.0.0-beta.4/index.global.min.js'></script> -->
+<script src='https://usetrmnl.com/fullcalendar/index.global.min.js'></script>
 
 <script>
   document.addEventListener('DOMContentLoaded', function() {
@@ -26,8 +23,13 @@
       now: '<%= today_in_tz %>',
       timeZone: new Date('<%= events.values.flatten.reject { |e| e[:all_day] }.first&.dig(:start_full) %>').getTimezoneOffset(),
       headerToolbar: false,
+      contentHeight: 'auto', // removes scrollbar that can appear in top right
       initialView: 'dayGridMonth',
       firstDay: <%= first_day %>,
+      eventTimeFormat: {
+        hour: 'numeric', // required for 0-24 number to appear at all
+        hour12: <%= time_format == 'am/pm' %> // if true: 1-12; if false: 0-23
+      },
       events: <%== events.values.flatten.map {|e| { allDay: e[:all_day], title: e[:summary], description: e[:description], start: e[:start_full], end: e[:end_full] } }.to_json %>,
       displayEventTime: <%= include_event_time %>,
       locale: '<%= locale %>',

--- a/lib/calendar/views/_full_week.html.erb
+++ b/lib/calendar/views/_full_week.html.erb
@@ -33,7 +33,8 @@
 
 <div id="calendar" style="height: 480px; width: 800px"></div>
 
-<script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.js'></script>
+<script src='https://usetrmnl.com/fullcalendar/index.global.min.js'></script>
+
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     var calendarEl = document.getElementById('calendar');
@@ -41,6 +42,7 @@
       now: '<%= today_in_tz %>',
       timeZone: new Date('<%= events.values.flatten.reject { |e| e[:all_day] }.first&.dig(:start_full) %>').getTimezoneOffset(),
       headerToolbar: false,
+      contentHeight: 'auto', // removes scrollbar that can appear in top right
       initialView: 'timeGridFourDay', // 'dayGridWeek' shows a week but does not show events as blocks with diff heights per time length
       scrollTime: '<%= scroll_time %>', // without this, view begins at 12am (creating white space)
       slotMinTime: '<%= scroll_time %>', // required in-addition to scrollTime, otherwise calendar lib will ignore scrollTime if events would be hidden
@@ -49,6 +51,12 @@
           type: 'timeGrid',
           duration: { days: 7 }
         }
+      },
+      slotLabelFormat: {
+        hour: 'numeric', // required for 0-24 number to appear at all
+        meridiem: 'short', // 'pm' vs ' PM' (long); relevant if hour12=true
+        hour12: <%= time_format == 'am/pm' %>, // if true: 1-12; if false: 0-23
+        // omitZeroMinute: true, // may look nicer as 'true' if 24 hour time is enabled
       },
       locale: '<%= locale %>',
       slotDuration: '00:30:00', // could potentially leverage this to show full 24h view (change slot duration to 1h)

--- a/lib/calendar/views/_half_vertical.html.erb
+++ b/lib/calendar/views/_half_vertical.html.erb
@@ -1,17 +1,18 @@
 <div class="view view--half_vertical">
   <div class="layout" style="flex-flow: wrap;">
-    <div class="column">
-      <% events.sort_by { |k,_v| Date.parse(k.to_s) }.first(4).to_h.each do |day_of_events| %>
+    <div class="column" data-list-limit="true" data-list-max-height="340" data-list-hidden-count="true">
+      <div class="list">
+      <% events.sort_by { |k,_v| Date.parse(k.to_s) }.first(3).to_h.each do |day_of_events| %>
         <% all_day_events = day_of_events[1].select { |e| e[:all_day] } %>
-        <% visible_events = (day_of_events[1] - all_day_events) %>
-        <div class="list">
+        <% regular_events = (day_of_events[1] - all_day_events) %>
+
           <span class="label"><%= day_of_events[0] %></span>
 
           <% all_day_events.each do |event| %>
             <%= render partial: 'plugins/calendars/all_day_event', locals: { event: event, include_description: } %>
           <% end %>
 
-          <% visible_events.each_with_index do |event, idx| %>
+          <% regular_events.each_with_index do |event, idx| %>
             <div class="item">
               <div class="meta">
                 <span class="index"><%= idx + 1 %></span>
@@ -25,8 +26,8 @@
               </div>
             </div>
           <% end %>
-        </div>
       <% end %>
+      </div>
     </div>
   </div>
 

--- a/lib/calendar/views/_quadrant.html.erb
+++ b/lib/calendar/views/_quadrant.html.erb
@@ -1,31 +1,32 @@
 <div class="view view--quadrant">
-  <div class="layout layout--col" style="justify-content: <%= events.count > 1 ? 'flex-start' : 'center' %>">
-    <% events.sort_by { |k,_v| Date.parse(k.to_s) }.first(2).to_h.each do |day_of_events| %>
-      <% all_day_events = day_of_events[1].select { |e| e[:all_day] } %>
-      <% visible_events = (day_of_events[1] - all_day_events) %>
-
+  <div class="layout" style="flex-flow: wrap;">
+    <div class="column" data-list-limit="true" data-list-max-height="140" data-list-hidden-count="true">
       <div class="list">
-        <span class="label"><%= day_of_events[0] %></span>
+        <% events.sort_by { |k,_v| Date.parse(k.to_s) }.first(2).to_h.each do |day_of_events| %>
+          <% all_day_events = day_of_events[1].select { |e| e[:all_day] } %>
+          <% regular_events = (day_of_events[1] - all_day_events) %>
+            <span class="label"><%= day_of_events[0] %></span>
 
-        <% all_day_events.each do |event| %>
-          <%= render partial: 'plugins/calendars/all_day_event', locals: { event: event, include_description: } %>
-        <% end %>
+            <% all_day_events.each do |event| %>
+              <%= render partial: 'plugins/calendars/all_day_event', locals: { event: event, include_description: } %>
+            <% end %>
 
-        <% visible_events.each_with_index do |event, idx| %>
-          <div class="item">
-            <div class="meta">
-              <span class="index"><%= idx + 1 %></span>
-            </div>
-            <div class="content">
-              <span class="title title--small"><%= event[:summary] %></span>
-              <div class="flex gap--xsmall">
-                <span class="label label--small label--underline"><%= "#{event[:start]}" %> - <%= event[:end] %></span>
+            <% regular_events.each_with_index do |event, idx| %>
+              <div class="item">
+                <div class="meta">
+                  <span class="index"><%= idx + 1 %></span>
+                </div>
+                <div class="content">
+                  <span class="title title--small"><%= event[:summary] %></span>
+                  <div class="flex gap--xsmall">
+                    <span class="label label--small label--underline"><%= "#{event[:start]}" %> - <%= event[:end] %></span>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
+            <% end %>
         <% end %>
       </div>
-    <% end %>
+    </div>
   </div>
 
   <%= render partial: "plugins/calendars/title_bar", locals: local_assigns %>


### PR DESCRIPTION
**Google Calendar**

* ability to exclude events by exact OR partial match (title, description fields)
* fixes "past events" not always appearing

All calendars

* include day of week in Default layout headings, ex `Monday, May 12`
* remove inner scroll bar if a Week/Month view has too many events
* fixes support for am/pm vs 24 hour in Week/Month views
* fixes occasional empty event boxes in Week/Month views by loading FullCalendar from TRMNL CDN