### PR TITLE
Add sunset next to sunrise

### DIFF
--- a/lib/tempest_weather_station/views/full.html.erb
+++ b/lib/tempest_weather_station/views/full.html.erb
@@ -10,8 +10,14 @@
           <div class="content">
             <span class="value value--xxxlarge" data-fit-value="true"><%= temperature&.round %>°</span>
             <span class="label w--full">
-              <img style="max-height: 24px; vertical-align: middle" src="<%= Rails.application.credentials.base_url %>/images/plugins/weather/wi-sunrise.svg" />
-              <%= forecast[:right_now][:sunrise] %>
+              <div class="content">
+                <img style="max-height: 24px; vertical-align: middle" src="<%= Rails.application.credentials.base_url %>/images/plugins/weather/wi-sunrise.svg" />
+                <%= forecast[:right_now][:sunrise] %>
+              </div>
+              <div class="content">
+                <img style="max-height: 24px; vertical-align: middle" src="<%= Rails.application.credentials.base_url %>/images/plugins/weather/wi-sunset.svg" />
+                <%= forecast[:right_now][:sunset] %>
+              </div>
             </span>
             <span class="label w--full">
               <img style="max-height: 24px; vertical-align: middle" src="https://tempestwx.com/images/Updated/wind-arrow-<%= forecast[:right_now][:wind][:direction_cardinal].downcase %>.svg" />


### PR DESCRIPTION
added sunset right next to sunrise so it shows both. Put within columns rather than just concat'ed in the same row to be visually consistent with the forecast layout. Unsure how that affects spacing (hard to test).