### PR TITLE
Fix moon phase localization by preventing MOON_PHASES constant mutation

### DIFF
--- a/lib/lunar_calendar/lunar_calendar.rb
+++ b/lib/lunar_calendar/lunar_calendar.rb
@@ -115,8 +115,9 @@ module Plugins
 
     def localized_moon_phases
       MOON_PHASES.map do |phase|
-        phase[:name] = t("renders.lunar_calendar.moon_phases.#{phase[:keyname]}", locale:)
-        phase
+        phase.dup.tap do |localized_phase|
+          localized_phase[:name] = t("renders.lunar_calendar.moon_phases.#{phase[:keyname]}", locale:)
+        end
       end
     end
 


### PR DESCRIPTION
The localization does not work for the current_phase and instead falls back to the original, English string (`Waxing Crescent` in this example):

![grafik](https://github.com/user-attachments/assets/5fc3baa0-ff7d-49f8-acfd-321d4fee3133)

According to my research, this should be fixed by duplicating the hash before modification, preventing mutation of the MOON_PHASES constant.

Hoping I'm on the right track here ...