### PR TITLE
Disable x-axis labels in quadrant view

### DIFF
--- a/lib/withings/views/quadrant.html.erb
+++ b/lib/withings/views/quadrant.html.erb
@@ -27,7 +27,7 @@
                       chart: { height: 112 },
                       plotOptions: { series: { animation: false, lineWidth: 4 } },
                       yAxis: { min: metrics.map { it.values.first }.min - 2, labels: { style: { fontSize: '16px', color: '#000000' } }, gridLineDashStyle: 'shortdot', gridLineWidth: 1, gridLineColor: '#000000', tickAmount: 5 },
-                      xAxis: { type: 'daytime', labels: { style: { fontSize: '16px', color: '#000000' } }, lineWidth: 0, gridLineDashStyle: 'dot', tickWidth: 1, tickLength: 0, gridLineWidth: 1, gridLineColor: '#000000', tickPixelInterval: 120 }}
+                      xAxis: { type: 'daytime', labels: { enabled: false }, lineWidth: 0, gridLineDashStyle: 'dot', tickWidth: 1, tickLength: 0, gridLineWidth: 1, gridLineColor: '#000000', tickPixelInterval: 120 }}
     %>
   </div>
 


### PR DESCRIPTION
User noticed that the Quadrant view in Withings is not really usable. This PR tries to solve this by removing the x-axis labels (month names) to allow more space for the graph itself.