### PR TITLE
Rotate xAxis label from 45 to 90 degrees

### DIFF
--- a/lib/withings/views/half_vertical.html.erb
+++ b/lib/withings/views/half_vertical.html.erb
@@ -27,7 +27,7 @@
                       chart: { height: 280 },
                       plotOptions: { series: { animation: false, lineWidth: 4 } },
                       yAxis: { min: metrics.map { it.values.first }.min - 5, labels: { style: { fontSize: '16px', color: '#000000' } }, gridLineDashStyle: 'shortdot', gridLineWidth: 1, gridLineColor: '#000000', tickAmount: 5 },
-                      xAxis: { type: 'daytime', labels: { style: { fontSize: '16px', color: '#000000' } }, lineWidth: 0, gridLineDashStyle: 'dot', tickWidth: 1, tickLength: 0, gridLineWidth: 1, gridLineColor: '#000000', tickPixelInterval: 120 }}
+                      xAxis: { type: 'daytime', labels: { style: { fontSize: '16px', color: '#000000' }, rotation: 90 }, lineWidth: 0, gridLineDashStyle: 'dot', tickWidth: 1, tickLength: 0, gridLineWidth: 1, gridLineColor: '#000000', tickPixelInterval: 120 }}
     %>
   </div>
 


### PR DESCRIPTION
[User proposed](https://app.intercom.com/a/inbox/v9ws3u2x/inbox/admin/8768486/conversation/215470710098987?view=List) to rotate the x-Axis label in the Vertical view by 90 degrees instead of 45 degrees to have it more readable/less dither on the low-res display.

![IMG_1590](https://github.com/user-attachments/assets/5259a977-39a3-4a72-9b7e-93e295b42a19)
