### PR TITLE
Add Beszel Server Stats to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,5 +96,6 @@ native plugin structure:
 - [YoLink Temperature](https://github.com/erikbuild/trmnl-yolink-temperature) by [@erikbuild](https://github.com/erikbuild)
 - [Anki](https://github.com/ItsJustThomas/trmnl-anki) by [@ItsJustThomas](https://github.com/ItsJustThomas)
 - [Obsidian](https://github.com/vaaski/trmnl-custom-plugins?tab=readme-ov-file#obsidian-daily-notes) by [@vaaski](https://github.com/vaaski)
+- [Beszel Server Stats](https://github.com/mr-karan/trmnl-beszel) by [@mr-karan](https://github.com/mr-karan)
 
 to be featured here, add `trmnl` topic to your repo, then open a PR or join the developer-only Discord server (link inside TRMNL UI).


### PR DESCRIPTION
Adds a one-line entry to the Community plugins section for my new plugin.

- Repo: https://github.com/mr-karan/trmnl-beszel
- `trmnl` topic: set
- License: MIT

The plugin shows live server stats from a [Beszel](https://beszel.dev) hub (CPU / memory / disk / load / temperature per host) on a TRMNL device. Self-hosted Docker stack pushes a compact JSON payload to a Private Plugin webhook every 5 minutes; TRMNL renders the provided Liquid template into the e-ink frame.