### PR TITLE
Add TRMNL Plugin Preview to plugin utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ native plugin structure:
 ## Plugin utilities
 
 - [trmnl_preview](https://github.com/schrockwell/trmnl_preview) by [@schrockwell](https://github.com/schrockwell)
+- [TRMNL Plugin Preview](https://github.com/danmunoz/trmnl-plugin-preview) by [@danmunoz](https://github.com/danmunoz)
 - [TRMNL plugin Dev Kit](https://github.com/sdjmchattie/trmnl-plugin-dev-kit) by [@sdjmchattie](https://github.com/sdjmchattie)
 - [plugin generator [Laravel]](https://github.com/bnussbau/laravel-trmnl) by [@bnussbau](https://github.com/bnussbau)
 - [TRMNL api simulator](https://github.com/deisterhold/trmnl-simulator) by [@deisterhold](https://github.com/deisterhold)


### PR DESCRIPTION
## Summary
- add `TRMNL Plugin Preview` to the `Plugin utilities` section in `README.md`
- link to the public repo: https://github.com/danmunoz/trmnl-plugin-preview
- confirm the repo includes the required `trmnl` topic

## Why
`TRMNL Plugin Preview` is a local preview server for third-party TRMNL plugin markup endpoints. It helps plugin authors validate markup, render the four TRMNL layout variants, inspect endpoint diagnostics, and export PNG previews during development.