### PR TITLE
Add OutageDeck vendor status plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,5 +103,6 @@ native plugin structure:
 - [Mod Analytics](https://github.com/me4502/trmnl-mod-analytics) by [@me4502](https://github.com/me4502)
 - [RuneScape HiScores](https://github.com/me4502/trmnl-runescape) by [@me4502](https://github.com/me4502)
 - [Rebigulator](https://github.com/me4502/trmnl-rebigulator) by [@me4502](https://github.com/me4502)
+- [Multi-vendor cloud & SaaS status](https://github.com/outagedeck/trmnl-plugin) by [OutageDeck](https://github.com/outagedeck)
 
 to be featured here, add `trmnl` topic to your repo, then open a PR or join the developer-only Discord server (link inside TRMNL UI).


### PR DESCRIPTION
Adds the OutageDeck community plugin to the directory. It addresses #121 by normalizing mixed provider sources such as GitHub, Slack, and AWS instead of requiring every URL to use Atlassian Statuspage.

The linked repository has the required `trmnl` topic, four layouts, a rendered one-bit device preview, an MIT license, and a passing official `trmnlp` lint run.