### PR TITLE
Add Live Tennis scores plugin to the community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,5 +105,6 @@ native plugin structure:
 - [RuneScape HiScores](https://github.com/me4502/trmnl-runescape) by [@me4502](https://github.com/me4502)
 - [Rebigulator](https://github.com/me4502/trmnl-rebigulator) by [@me4502](https://github.com/me4502)
 - [Multi-vendor cloud & SaaS status](https://github.com/outagedeck/trmnl-plugin) by [OutageDeck](https://github.com/outagedeck)
+- [Live tennis scores](https://github.com/livetennisapi/trmnl-live-tennis) by [@livetennisapi](https://github.com/livetennisapi)
 
 to be featured here, add `trmnl` topic to your repo, then open a PR or join the developer-only Discord server (link inside TRMNL UI).


### PR DESCRIPTION
Adds [Live Tennis](https://github.com/livetennisapi/trmnl-live-tennis) to the community plugins list — live ATP/WTA/Challenger/ITF/juniors scores (per-set games, current points, serving indicator, derived break-point marker) across all four views, built on the trmnlp scaffold with `trmnlp lint` in CI. The repo carries the `trmnl` topic.

Disclosure: I maintain the API behind it (Live Tennis API); the plugin's default 15-minute refresh fits the API's free tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
