### PR TITLE
Support Notion page tables across all layouts

### DIFF
--- a/lib/notion/notion.rb
+++ b/lib/notion/notion.rb
@@ -322,6 +322,8 @@ module Plugins
         block_type = block["type"]
         block_data = block[block_type] || {}
 
+        next format_table_block(block, block_data) if block_type == "table"
+
         {
           type: block_type,
           text: extract_block_text(block_data, block),
@@ -331,6 +333,42 @@ module Plugins
           caption: extract_image_caption(block)
         }
       end
+    end
+
+    def format_table_block(block, block_data)
+      rows = fetch_table_rows(block["id"]).map do |row|
+        Array(row.dig("table_row", "cells")).map { |cell| extract_rich_text(cell) }
+      end
+
+      table_width = block_data["table_width"].to_i
+      table_width = rows.map(&:length).max.to_i if table_width.zero?
+
+      {
+        type: "table",
+        table_width: table_width,
+        has_column_header: block_data["has_column_header"] == true,
+        has_row_header: block_data["has_row_header"] == true,
+        rows: normalize_table_rows(rows, table_width)
+      }
+    end
+
+    def fetch_table_rows(table_id)
+      response = api_client.get_page_blocks(table_id, page_size: 100)
+      Array(response["results"]).select { |block| block["type"] == "table_row" }
+    end
+
+    def normalize_table_rows(rows, table_width)
+      return [] if table_width.zero?
+
+      rows.map do |row|
+        normalized_row = row.first(table_width)
+        normalized_row.fill("", normalized_row.length...table_width)
+      end
+    end
+
+    def extract_rich_text(rich_text)
+      text = Array(rich_text).map { |fragment| fragment["plain_text"] || fragment.dig("text", "content") }.join
+      strip_emojis(text)
     end
 
     def extract_block_text(block_data, block)

--- a/lib/notion/notion.rb
+++ b/lib/notion/notion.rb
@@ -336,7 +336,8 @@ module Plugins
     end
 
     def format_table_block(block, block_data)
-      rows = fetch_table_rows(block["id"]).map do |row|
+      table_data = fetch_table_data(block["id"])
+      rows = table_data[:rows].map do |row|
         Array(row.dig("table_row", "cells")).map { |cell| extract_rich_text(cell) }
       end
 
@@ -348,13 +349,25 @@ module Plugins
         table_width: table_width,
         has_column_header: block_data["has_column_header"] == true,
         has_row_header: block_data["has_row_header"] == true,
+        has_more_rows: table_data[:has_more],
         rows: normalize_table_rows(rows, table_width)
       }
     end
 
-    def fetch_table_rows(table_id)
-      response = api_client.get_page_blocks(table_id, page_size: 100)
-      Array(response["results"]).select { |block| block["type"] == "table_row" }
+    def fetch_table_data(table_id)
+      @table_data ||= {}
+      @table_data[table_id] ||= begin
+        response = api_client.get_page_blocks(table_id, page_size: 100)
+        results = response.is_a?(Hash) ? response["results"] : nil
+
+        {
+          rows: Array(results).select { |block| block.is_a?(Hash) && block["type"] == "table_row" },
+          has_more: response.is_a?(Hash) && response["has_more"] == true
+        }
+      rescue StandardError => e
+        Rails.logger.error "Notion table API error: #{e.message}"
+        { rows: [], has_more: false }
+      end
     end
 
     def normalize_table_rows(rows, table_width)
@@ -367,7 +380,11 @@ module Plugins
     end
 
     def extract_rich_text(rich_text)
-      text = Array(rich_text).map { |fragment| fragment["plain_text"] || fragment.dig("text", "content") }.join
+      text = Array(rich_text).filter_map do |fragment|
+        next unless fragment.is_a?(Hash)
+
+        fragment["plain_text"] || fragment.dig("text", "content")
+      end.join
       strip_emojis(text)
     end
 

--- a/lib/notion/views/full.html.erb
+++ b/lib/notion/views/full.html.erb
@@ -22,22 +22,30 @@
       <% end %>
     </div>
   <% elsif display_type == "page" %>
-    <div class="layout layout--top">
-      <% if items && items[:blocks] && items[:blocks].any? %>
-        <div class="columns" data-overflow-max-cols="<%= multi_column_display %>" data-overflow-counter="false">
-          <div class="column">
+    <% if items && items[:blocks] && items[:blocks].any? %>
+      <% has_table = items[:blocks].any? { |block| block[:type] == "table" } %>
+      <div class="layout layout--top<%= " notion-table-layout" if has_table %>">
+        <% if has_table %>
+          <div class="notion-table-columns">
+            <div class="notion-table-column">
+        <% else %>
+          <div class="columns" data-overflow-max-cols="<%= multi_column_display %>" data-overflow-counter="false">
+            <div class="column">
+        <% end %>
             <% items[:blocks].each_with_index do |block, idx| %>
               <%= render 'plugins/notion/shared/page_block', block: block, index: idx, current_layout: "full", image_height: image_height %>
             <% end %>
           </div>
         </div>
-      <% else %>
+      </div>
+    <% else %>
+      <div class="layout layout--top">
         <%= render 'plugins/notion/shared/error_section',
                    title_class: "title",
                    title_text: "No Content Available",
                    description_text: "Check your Notion configuration and try again" %>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   <% end %>
 
   <%= render partial: 'plugins/notion/shared/title_bar', locals: { instance_name: instance_name } %>

--- a/lib/notion/views/full.html.erb
+++ b/lib/notion/views/full.html.erb
@@ -23,7 +23,7 @@
     </div>
   <% elsif display_type == "page" %>
     <% if items && items[:blocks] && items[:blocks].any? %>
-      <% has_table = items[:blocks].any? { |block| block[:type] == "table" } %>
+      <% has_table = items[:blocks].any? { |block| block[:type] == "table" && Array(block[:rows]).any? && block[:table_width].to_i.positive? } %>
       <div class="layout layout--top<%= " notion-table-layout" if has_table %>">
         <% if has_table %>
           <div class="notion-table-columns">

--- a/lib/notion/views/half_horizontal.html.erb
+++ b/lib/notion/views/half_horizontal.html.erb
@@ -23,7 +23,7 @@
     </div>
   <% elsif display_type == "page" %>
     <% if items && items[:blocks] && items[:blocks].any? %>
-      <% has_table = items[:blocks].any? { |block| block[:type] == "table" } %>
+      <% has_table = items[:blocks].any? { |block| block[:type] == "table" && Array(block[:rows]).any? && block[:table_width].to_i.positive? } %>
       <div class="layout layout--top<%= " notion-table-layout" if has_table %>">
         <% if has_table %>
           <div class="notion-table-columns">

--- a/lib/notion/views/half_horizontal.html.erb
+++ b/lib/notion/views/half_horizontal.html.erb
@@ -22,22 +22,30 @@
       <% end %>
     </div>
   <% elsif display_type == "page" %>
-    <div class="layout layout--top">
-      <% if items && items[:blocks] && items[:blocks].any? %>
-        <div class="columns" data-overflow-max-cols="<%= multi_column_display %>" data-overflow-counter="false">
-          <div class="column">
+    <% if items && items[:blocks] && items[:blocks].any? %>
+      <% has_table = items[:blocks].any? { |block| block[:type] == "table" } %>
+      <div class="layout layout--top<%= " notion-table-layout" if has_table %>">
+        <% if has_table %>
+          <div class="notion-table-columns">
+            <div class="notion-table-column">
+        <% else %>
+          <div class="columns" data-overflow-max-cols="<%= multi_column_display %>" data-overflow-counter="false">
+            <div class="column">
+        <% end %>
             <% items[:blocks].each_with_index do |block, idx| %>
               <%= render 'plugins/notion/shared/page_block', block: block, index: idx, current_layout: "half_horizontal", image_height: image_height %>
             <% end %>
           </div>
         </div>
-      <% else %>
+      </div>
+    <% else %>
+      <div class="layout layout--top">
         <%= render 'plugins/notion/shared/error_section',
                    title_class: "title title--small",
                    title_text: "No Content",
                    description_text: "Check your Notion configuration" %>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   <% end %>
 
   <%= render partial: 'plugins/notion/shared/title_bar', locals: { instance_name: instance_name } %>

--- a/lib/notion/views/half_vertical.html.erb
+++ b/lib/notion/views/half_vertical.html.erb
@@ -23,7 +23,7 @@
     </div>
   <% elsif display_type == "page" %>
     <% if items && items[:blocks] && items[:blocks].any? %>
-      <% has_table = items[:blocks].any? { |block| block[:type] == "table" } %>
+      <% has_table = items[:blocks].any? { |block| block[:type] == "table" && Array(block[:rows]).any? && block[:table_width].to_i.positive? } %>
       <div class="layout layout--top<%= " notion-table-layout" if has_table %>">
         <% if has_table %>
           <div class="notion-table-columns">

--- a/lib/notion/views/half_vertical.html.erb
+++ b/lib/notion/views/half_vertical.html.erb
@@ -21,23 +21,31 @@
                    description_text: "Check your Notion configuration" %>
       <% end %>
     </div>
-<% elsif display_type == "page" %>
-    <div class="layout layout--top">
-      <% if items && items[:blocks] && items[:blocks].any? %>
-        <div class="columns" data-overflow-max-cols="1" data-overflow-counter="false">
-          <div class="column">
+  <% elsif display_type == "page" %>
+    <% if items && items[:blocks] && items[:blocks].any? %>
+      <% has_table = items[:blocks].any? { |block| block[:type] == "table" } %>
+      <div class="layout layout--top<%= " notion-table-layout" if has_table %>">
+        <% if has_table %>
+          <div class="notion-table-columns">
+            <div class="notion-table-column">
+        <% else %>
+          <div class="columns" data-overflow-max-cols="1" data-overflow-counter="false">
+            <div class="column">
+        <% end %>
             <% items[:blocks].each_with_index do |block, idx| %>
               <%= render 'plugins/notion/shared/page_block', block: block, index: idx, current_layout: "half_vertical", image_height: image_height %>
             <% end %>
           </div>
         </div>
-      <% else %>
+      </div>
+    <% else %>
+      <div class="layout layout--top">
         <%= render 'plugins/notion/shared/error_section',
                    title_class: "title title--small",
                    title_text: "No Content",
                    description_text: "Check your Notion configuration" %>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   <% end %>
 
   <%= render partial: 'plugins/notion/shared/title_bar', locals: { instance_name: instance_name } %>

--- a/lib/notion/views/quadrant.html.erb
+++ b/lib/notion/views/quadrant.html.erb
@@ -22,22 +22,30 @@
       <% end %>
     </div>
   <% elsif display_type == "page" %>
-    <div class="layout layout--top">
-      <% if items && items[:blocks] && items[:blocks].any? %>
-        <div class="columns" data-overflow-max-cols="1" data-overflow-counter="false">
-          <div class="column">
+    <% if items && items[:blocks] && items[:blocks].any? %>
+      <% has_table = items[:blocks].any? { |block| block[:type] == "table" } %>
+      <div class="layout layout--top<%= " notion-table-layout" if has_table %>">
+        <% if has_table %>
+          <div class="notion-table-columns">
+            <div class="notion-table-column">
+        <% else %>
+          <div class="columns" data-overflow-max-cols="1" data-overflow-counter="false">
+            <div class="column">
+        <% end %>
             <% items[:blocks].each_with_index do |block, idx| %>
               <%= render 'plugins/notion/shared/page_block', block: block, index: idx, current_layout: "quadrant", image_height: image_height %>
             <% end %>
           </div>
         </div>
-      <% else %>
+      </div>
+    <% else %>
+      <div class="layout layout--top">
         <%= render 'plugins/notion/shared/error_section',
                    title_class: "title title--small",
                    title_text: "No Content",
                    description_text: "Check config" %>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   <% end %>
 
   <%= render partial: 'plugins/notion/shared/title_bar', locals: { instance_name: instance_name } %>

--- a/lib/notion/views/quadrant.html.erb
+++ b/lib/notion/views/quadrant.html.erb
@@ -23,7 +23,7 @@
     </div>
   <% elsif display_type == "page" %>
     <% if items && items[:blocks] && items[:blocks].any? %>
-      <% has_table = items[:blocks].any? { |block| block[:type] == "table" } %>
+      <% has_table = items[:blocks].any? { |block| block[:type] == "table" && Array(block[:rows]).any? && block[:table_width].to_i.positive? } %>
       <div class="layout layout--top<%= " notion-table-layout" if has_table %>">
         <% if has_table %>
           <div class="notion-table-columns">

--- a/lib/notion/views/shared/_page_block.html.erb
+++ b/lib/notion/views/shared/_page_block.html.erb
@@ -1,6 +1,8 @@
 <% if block[:type] == "divider" %>
   <div style="border-top: 1px dotted #000000;"></div>
-<% elsif ["table_of_contents", "table", "unsupported", "synced_block", "breadcrumb", "column_list"].include?(block[:type]) %>
+<% elsif block[:type] == "table" %>
+  <%= render 'plugins/notion/shared/table', table: block, current_layout: current_layout %>
+<% elsif ["table_of_contents", "unsupported", "synced_block", "breadcrumb", "column_list"].include?(block[:type]) %>
   <% return %>
 <% else %>
   <div class="item">

--- a/lib/notion/views/shared/_table.html.erb
+++ b/lib/notion/views/shared/_table.html.erb
@@ -1,0 +1,192 @@
+<%
+  layout_limits = {
+    "full" => { rows: 12, columns: 8, lines: 3 },
+    "half_horizontal" => { rows: 6, columns: 8, lines: 2 },
+    "half_vertical" => { rows: 10, columns: 4, lines: 3 },
+    "quadrant" => { rows: 6, columns: 4, lines: 2 }
+  }
+  limits = layout_limits.fetch(current_layout, layout_limits["full"])
+
+  source_rows = Array(table[:rows]).map { |row| Array(row) }
+  source_column_count = table[:table_width].to_i
+  source_column_count = source_rows.map(&:length).max.to_i if source_column_count.zero?
+
+  hidden_column_count = source_column_count > limits[:columns] ? source_column_count - limits[:columns] + 1 : 0
+  visible_source_columns = hidden_column_count.positive? ? limits[:columns] - 1 : source_column_count
+  displayed_column_count = [source_column_count, limits[:columns]].min
+
+  hidden_row_count = source_rows.length > limits[:rows] ? source_rows.length - limits[:rows] + 1 : 0
+  visible_source_rows = hidden_row_count.positive? ? limits[:rows] - 1 : source_rows.length
+
+  rows = source_rows.first(visible_source_rows).map.with_index do |row, row_index|
+    cells = row.first(visible_source_columns)
+    cells.fill("", cells.length...visible_source_columns)
+    cells << (row_index.zero? ? "+#{hidden_column_count} cols" : "…") if hidden_column_count.positive?
+    cells
+  end
+
+  if hidden_row_count.positive?
+    summary_row = Array.new(displayed_column_count, "…")
+    summary_row[0] = "+#{hidden_row_count} rows"
+    rows << summary_row
+  end
+
+  dense = rows.length > 8 || displayed_column_count > 6
+  line_limit = dense ? [limits[:lines], 2].min : limits[:lines]
+%>
+
+<% if rows.any? && displayed_column_count.positive? %>
+  <style>
+    .notion-table-layout,
+    .notion-table-layout > .notion-table-columns,
+    .notion-table-layout > .notion-table-columns > .notion-table-column {
+      height: 100%;
+      min-height: 0;
+    }
+
+    .notion-table-columns {
+      width: 100%;
+      overflow: hidden;
+    }
+
+    .notion-table-column {
+      display: flex;
+      flex-direction: column;
+      gap: var(--gap);
+    }
+
+    .notion-table-frame {
+      width: 100%;
+      min-height: 0;
+      overflow: hidden;
+    }
+
+    .notion-table-layout .notion-table-frame {
+      flex: 1 1 0;
+    }
+
+    .notion-table {
+      display: grid;
+      grid-template-columns: repeat(var(--notion-table-columns), minmax(0, 1fr));
+      grid-template-rows: repeat(var(--notion-table-rows), minmax(0, 1fr));
+      width: 100%;
+      height: 100%;
+      min-height: 0;
+      overflow: hidden;
+      border-top: 1px solid var(--framework-border-strong, #000);
+      border-left: 1px solid var(--framework-border-strong, #000);
+      box-sizing: border-box;
+      color: var(--framework-text-primary, #000);
+    }
+
+    .notion-table.notion-table > thead,
+    .notion-table.notion-table > tbody,
+    .notion-table.notion-table tr {
+      display: contents;
+    }
+
+    .notion-table th,
+    .notion-table td {
+      --notion-cell-pad-block: calc(3px * var(--content-scale, 1));
+      --notion-cell-pad-inline: calc(5px * var(--content-scale, 1));
+      --notion-cell-font: calc(14px * var(--text-ui-scale, 1));
+      --notion-cell-leading: 1.1;
+      display: flex;
+      align-items: center;
+      min-width: 0;
+      min-height: 0;
+      overflow: hidden;
+      padding: var(--notion-cell-pad-block) var(--notion-cell-pad-inline);
+      border-right: 1px solid var(--framework-border-strong, #000);
+      border-bottom: 1px solid var(--framework-border-strong, #000);
+      box-sizing: border-box;
+      font-size: var(--notion-cell-font);
+      font-weight: 400;
+      line-height: var(--notion-cell-leading);
+      overflow-wrap: anywhere;
+      white-space: pre-wrap;
+    }
+
+    .notion-table .notion-table__cell--header,
+    .notion-table .notion-table__cell--summary {
+      background-color: var(--framework-fill-soft, #e5e5e5);
+      font-weight: 700;
+    }
+
+    .notion-table .notion-table__cell--important {
+      background-color: var(--framework-slot-chip-bg-color, var(--framework-fill-strong, #000));
+      background-image: var(--framework-slot-chip-bg-image, none);
+      color: var(--framework-slot-chip-text-color, var(--framework-text-inverse, #fff));
+      -webkit-text-fill-color: currentColor;
+      font-weight: 700;
+    }
+
+    .notion-table__text {
+      display: block;
+      width: 100%;
+      min-width: 0;
+      overflow: hidden;
+    }
+
+    .notion-table--dense th,
+    .notion-table--dense td {
+      --notion-cell-pad-block: calc(2px * var(--content-scale, 1));
+      --notion-cell-pad-inline: calc(4px * var(--content-scale, 1));
+      --notion-cell-font: calc(12px * var(--text-ui-scale, 1));
+      --notion-cell-leading: 1.05;
+    }
+
+    .notion-table--half_horizontal th,
+    .notion-table--half_horizontal td {
+      --notion-cell-pad-block: calc(2px * var(--content-scale, 1));
+      --notion-cell-pad-inline: calc(4px * var(--content-scale, 1));
+      --notion-cell-font: calc(11px * var(--text-ui-scale, 1));
+      --notion-cell-leading: 1.1;
+    }
+
+    .notion-table--half_vertical th,
+    .notion-table--half_vertical td {
+      --notion-cell-pad-block: calc(3px * var(--content-scale, 1));
+      --notion-cell-pad-inline: calc(3px * var(--content-scale, 1));
+      --notion-cell-font: calc(11px * var(--text-ui-scale, 1));
+      --notion-cell-leading: 1.1;
+    }
+
+    .notion-table--quadrant th,
+    .notion-table--quadrant td {
+      --notion-cell-pad-block: calc(2px * var(--content-scale, 1));
+      --notion-cell-pad-inline: calc(2px * var(--content-scale, 1));
+      --notion-cell-font: calc(10px * var(--text-ui-scale, 1));
+      --notion-cell-leading: 1.05;
+    }
+  </style>
+
+  <% has_column_header = table[:has_column_header] && visible_source_rows.positive? %>
+  <div class="notion-table-frame">
+    <table class="table notion-table notion-table--<%= current_layout %><%= " notion-table--dense" if dense %>"
+           aria-rowcount="<%= source_rows.length %>"
+           aria-colcount="<%= source_column_count %>"
+           style="--notion-table-columns: <%= displayed_column_count %>; --notion-table-rows: <%= rows.length %>;">
+      <% rows.each_with_index do |row, row_index| %>
+        <% if has_column_header && row_index.zero? %><thead><% elsif row_index == (has_column_header ? 1 : 0) %><tbody><% end %>
+        <tr>
+          <% row.each_with_index do |cell, column_index| %>
+            <% summary = (hidden_row_count.positive? && row_index == rows.length - 1) || (hidden_column_count.positive? && column_index == row.length - 1) %>
+            <% header = (has_column_header && row_index.zero?) || (table[:has_row_header] && column_index.zero?) %>
+            <% important = !summary && cell.to_s.lines.any? { |line| line.lstrip.start_with?("!") } %>
+            <% cell_classes = ["notion-table__cell"] %>
+            <% cell_classes << "notion-table__cell--header" if header %>
+            <% cell_classes << "notion-table__cell--summary" if summary %>
+            <% cell_classes << "notion-table__cell--important" if important %>
+            <% tag_name = header ? "th" : "td" %>
+            <<%= tag_name %> class="<%= cell_classes.join(" ") %>"<% if header %> scope="<%= has_column_header && row_index.zero? ? "col" : "row" %>"<% end %>>
+              <span class="notion-table__text" data-clamp="<%= line_limit %>" data-pixel-perfect="true"><%= cell %></span>
+            </<%= tag_name %>>
+          <% end %>
+        </tr>
+        <% if has_column_header && row_index.zero? %></thead><% end %>
+      <% end %>
+      <% if rows.length > (has_column_header ? 1 : 0) %></tbody><% end %>
+    </table>
+  </div>
+<% end %>

--- a/lib/notion/views/shared/_table.html.erb
+++ b/lib/notion/views/shared/_table.html.erb
@@ -15,8 +15,11 @@
   visible_source_columns = hidden_column_count.positive? ? limits[:columns] - 1 : source_column_count
   displayed_column_count = [source_column_count, limits[:columns]].min
 
-  hidden_row_count = source_rows.length > limits[:rows] ? source_rows.length - limits[:rows] + 1 : 0
-  visible_source_rows = hidden_row_count.positive? ? limits[:rows] - 1 : source_rows.length
+  row_results_truncated = table[:has_more_rows] == true
+  needs_row_summary = source_rows.length > limits[:rows] || row_results_truncated
+  visible_source_rows = needs_row_summary ? [limits[:rows] - 1, source_rows.length].min : source_rows.length
+  hidden_row_count = source_rows.length - visible_source_rows
+  hidden_row_label = row_results_truncated ? "+#{[hidden_row_count, 1].max}+ rows" : "+#{hidden_row_count} rows"
 
   rows = source_rows.first(visible_source_rows).map.with_index do |row, row_index|
     cells = row.first(visible_source_columns)
@@ -25,19 +28,23 @@
     cells
   end
 
-  if hidden_row_count.positive?
+  if needs_row_summary
     summary_row = Array.new(displayed_column_count, "…")
-    summary_row[0] = "+#{hidden_row_count} rows"
+    summary_row[0] = hidden_row_label
     rows << summary_row
   end
 
   dense = rows.length > 8 || displayed_column_count > 6
   line_limit = dense ? [limits[:lines], 2].min : limits[:lines]
+  line_limit = 1 if %w[half_horizontal quadrant].include?(current_layout) && rows.length == limits[:rows]
 %>
 
 <% if rows.any? && displayed_column_count.positive? %>
   <style>
-    .notion-table-layout,
+    .notion-table-layout {
+      min-height: 0;
+    }
+
     .notion-table-layout > .notion-table-columns,
     .notion-table-layout > .notion-table-columns > .notion-table-column {
       height: 100%;
@@ -128,6 +135,11 @@
       overflow: hidden;
     }
 
+    .notion-table__text[data-clamp="1"] {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
     .notion-table--dense th,
     .notion-table--dense td {
       --notion-cell-pad-block: calc(2px * var(--content-scale, 1));
@@ -171,7 +183,7 @@
         <% if has_column_header && row_index.zero? %><thead><% elsif row_index == (has_column_header ? 1 : 0) %><tbody><% end %>
         <tr>
           <% row.each_with_index do |cell, column_index| %>
-            <% summary = (hidden_row_count.positive? && row_index == rows.length - 1) || (hidden_column_count.positive? && column_index == row.length - 1) %>
+            <% summary = (needs_row_summary && row_index == rows.length - 1) || (hidden_column_count.positive? && column_index == row.length - 1) %>
             <% header = (has_column_header && row_index.zero?) || (table[:has_row_header] && column_index.zero?) %>
             <% important = !summary && cell.to_s.lines.any? { |line| line.lstrip.start_with?("!") } %>
             <% cell_classes = ["notion-table__cell"] %>


### PR DESCRIPTION
## Summary

- Add support for rendering table blocks in Notion pages.
- Fetch each table's `table_row` child blocks from the Notion API.
- Render tables consistently across full, half-horizontal, half-vertical, and quadrant layouts.
- Preserve existing page rendering and overflow behavior for pages without tables.
- Isolate table API failures so one unavailable table does not fail the entire page.

## User-visible behavior

Notion page tables now support:

- Column headers and row headers as configured in Notion.
- Equal-width columns and equal-height rows.
- Multi-line cell content with explicit ellipsis when text does not fit.
- Scale-aware typography and spacing using the TRMNL Framework variables.
- An importance convention: when any line in a cell starts with `!`, that cell is rendered with inverse colors.
- Headings and other page blocks above a table without TRMNL's column overflow engine reordering them.
- A single-column presentation for pages containing a renderable table; the Multi-Column Display setting remains unchanged for pages without tables.

Compact layouts show an explicit `+N rows` or `+N cols` summary instead of silently dropping content.

## Layout limits

The limits below describe displayed rows and columns, including any overflow summary:

| Layout | Displayed rows | Displayed columns |
| --- | ---: | ---: |
| Full | 12 | 8 |
| Half horizontal | 6 | 8 |
| Half vertical | 10 | 4 |
| Quadrant | 6 | 4 |

The full layout provides the largest table preview. Every layout reports when the source exceeds its available rows or columns.

## Implementation notes

- Table rows are fetched through `get_page_blocks(table_id, page_size: 100)`.
- Child responses are memoized per table id for the lifetime of the plugin instance.
- Nil responses and per-table API exceptions degrade to an empty table while leaving other page blocks available.
- Non-`table_row` children are ignored.
- Notion's `has_more` state is preserved; a trailing `+` in a row summary marks the displayed count as a lower bound.
- Rich-text fragments in each cell are combined into plain text.
- Rows are normalized to Notion's declared `table_width`:
  - missing cells are padded;
  - excess cells are discarded;
  - the widest row is used as a fallback when `table_width` is absent.
- Tables use semantic `<table>`, `<thead>`, `<tbody>`, `<th>`, and `<td>` markup.
- CSS Grid is applied to the semantic table markup to guarantee equal row and column distribution.
- Text and spacing follow `--text-ui-scale` and `--content-scale`.
- Existing framework-managed columns remain unchanged for pages that do not contain tables.

## Validation

- Ruby syntax validation passes for `lib/notion/notion.rb`.
- All Notion ERB templates compile successfully.
- Targeted rendering checks cover:
  - child-row extraction;
  - nil responses and API exceptions;
  - per-table memoization;
  - malformed rich-text fragments;
  - rich-text combination;
  - emoji stripping;
  - row padding and truncation;
  - column and row headers;
  - importance highlighting;
  - exact layout boundaries;
  - row and column overflow summaries;
  - table and non-table page containers.
  - empty-table fallback to the framework overflow container;
  - pagination-aware lower-bound summaries.
- Official `trmnlp` lint passes for the parity fixture.
- All four layouts were rendered and visually inspected on the original 800×480 TRMNL dimensions.
- TRMNL X was tested at 1872×1404 with both enlarged content scale and enlarged text scale.

## Rollout note

This repository mirrors the native plugin implementation. If the production source of truth remains the TRMNL core repository, the corresponding change should be applied or synced there before announcing table support.

## Help Center update required

The current [Notion Help Center article](https://help.trmnl.com/en/articles/11882090-notion) still lists tables and their child blocks as unsupported and recommends avoiding tables.

When this change is deployed, please update that article using the copy below.

<details>
<summary>Ready-to-publish Help Center changes</summary>

### 1. Add after the “Page Display Type” section

#### Tables

Tables on Notion pages are supported. TRMNL fetches the rows belonging to a top-level table block and distributes the rows and columns evenly across the available screen space.

Supported table features include:

- Column headers and row headers configured in Notion
- Multi-line text within cells
- Equal-width columns and equal-height rows
- Scale-aware rendering across supported TRMNL devices
- Important-cell highlighting: start any line in a cell with `!` to display that cell using inverse colors

The Page Item Limit controls the number of top-level page blocks fetched. Table rows are fetched separately, up to 100 rows per table. If Notion reports additional rows beyond that response, the overflow summary uses a trailing `+` to indicate that its count is a lower bound.

Pages containing a renderable table use a single-column presentation so headings and table geometry remain in source order. The Multi-Column Display setting continues to apply to pages without tables.

The full-screen layout provides the largest table preview. Smaller mashup layouts display a more compact preview. When rows or columns do not fit, the final displayed row or column reports the omitted amount using `+N rows` or `+N cols`.

Long cell content may be shortened with an ellipsis to keep the table within the available screen space.

### 2. Replace “Notion Block Support Details” with

## Notion Block Support Details

The plugin fetches and displays most top-level Notion page blocks, including text, headings, lists, images, and tables.

- **Nested Content**
  - Nested block children are generally not displayed.
  - `table_row` children belonging to a supported top-level table block are fetched and displayed.
  - Children inside toggle blocks are not displayed.
  - Tables nested inside another block are not displayed.

- **Unsupported Types**
  - `table_of_contents`
  - unsupported types returned by the Notion API
  - `synced_block`
  - `breadcrumb`
  - `column_list`

- **Links**
  - Some links may not display properly, particularly links to other Notion pages. This depends on the response provided by the Notion API.

- **Numbered Lists**
  - Numbers are not displayed in numbered lists due to API limitations. Numbered lists appear as bullet points instead.

- **People Mentions**
  - People mentions display as `@anonymous` due to Notion API privacy restrictions.

- **Emojis**
  - Emojis are stripped from text due to TRMNL platform limitations.
  - This also applies to text inside table cells.

### 3. Replace “Best Practices” with

#### Best Practices

- Use simple, flat page structures for the most predictable results.
- Keep table cell content concise.
- Use the full-screen layout for the largest available table preview.
- Use mashup layouts when a compact table preview is sufficient.
- Use `!` at the beginning of a line only when the entire cell should be highlighted.
- Consider using a Notion database instead of a table when you need filtering, sorting, or structured properties.

</details>
